### PR TITLE
feat: Add ReceiveIp setting and listen port when opening socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Visual Studio 2015 database file
 *.VC.db
 
+# Rider (Jetbrains) project files
+.idea
+
 # Compiled Object files
 *.slo
 *.lo

--- a/Source/UDPWrapper/Private/UDPComponent.cpp
+++ b/Source/UDPWrapper/Private/UDPComponent.cpp
@@ -244,7 +244,7 @@ void FUDPNative::OpenReceiveSocket(const FString& InListenIP /*= TEXT("0.0.0.0")
 
 	if (OnReceiveOpened)
 	{
-		OnReceiveOpened(Settings.ReceivePort);
+		OnReceiveOpened(InListenPort);
 	}
 
 	UDPReceiver->Start();

--- a/Source/UDPWrapper/Public/UDPComponent.h
+++ b/Source/UDPWrapper/Public/UDPComponent.h
@@ -20,6 +20,10 @@ struct UDPWRAPPER_API FUDPSettings
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UDP Connection Properties")
 	int32 SendPort;
 
+	/** Default listen port e.g. 0.0.0.0*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UDP Connection Properties")
+	FString ReceiveIP;
+
 	/** Default connection port e.g. 3002*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UDP Connection Properties")
 	int32 ReceivePort;
@@ -71,13 +75,13 @@ public:
 	~FUDPNative();
 
 	//Send
-	void OpenSendSocket(const FString& InIP = TEXT("127.0.0.1"), const int32 InPort = 3000);
+	int32 OpenSendSocket(const FString& InIP = TEXT("127.0.0.1"), const int32 InPort = 3000);
 	void CloseSendSocket();
 
 	void EmitBytes(const TArray<uint8>& Bytes);
 
 	//Receive
-	void OpenReceiveSocket(const int32 InListenPort = 3002);
+	void OpenReceiveSocket(const FString& InIP = TEXT("0.0.0.0"), const int32 InListenPort = 3002);
 	void CloseReceiveSocket();
 
 	//Callback convenience
@@ -136,7 +140,7 @@ public:
 	* @param InPort the udp port you wish to connect to
 	*/
 	UFUNCTION(BlueprintCallable, Category = "UDP Functions")
-	void OpenSendSocket(const FString& InIP = TEXT("127.0.0.1"), const int32 InPort = 3000);
+	int32 OpenSendSocket(const FString& InIP = TEXT("127.0.0.1"), const int32 InPort = 3000);
 
 	/**
 	* Close the sending socket. This is usually automatically done on endplay.
@@ -148,7 +152,7 @@ public:
 	* Start listening at given port for udp messages. Will auto-listen on begin play by default
 	*/
 	UFUNCTION(BlueprintCallable, Category = "UDP Functions")
-	void OpenReceiveSocket(const int32 InListenPort = 3002);
+	void OpenReceiveSocket(const FString& InListenIP = TEXT("0.0.0.0"), const int32 InListenPort = 3002);
 
 	/**
 	* Close the receiving socket. This is usually automatically done on endplay.

--- a/Source/UDPWrapper/Public/UDPComponent.h
+++ b/Source/UDPWrapper/Public/UDPComponent.h
@@ -20,7 +20,7 @@ struct UDPWRAPPER_API FUDPSettings
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UDP Connection Properties")
 	int32 SendPort;
 
-	/** Default listen port e.g. 0.0.0.0*/
+	/** Default receiving socket IP string in form e.g. 0.0.0.0. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UDP Connection Properties")
 	FString ReceiveIP;
 

--- a/UDPWrapper.uplugin
+++ b/UDPWrapper.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.9.3",
+	"VersionName": "0.9.4",
 	"FriendlyName": "UDPWrapper",
 	"Description": "Convenience UDP wrapper plugin.",
 	"Category": "Networking",


### PR DESCRIPTION
Hey ! Here's some improvements I made in a personal project, I thought it would be cool to share them to the community. They do not cause any breaking change.

I had same needs as this issue: https://github.com/getnamo/udp-ue4/issues/7
I needed to get the listen port of my socket so I could listen responses from my server.

Moreover, running two clients and the server in my computer, I wasn't able to get any data from my server. Looks like the default listening IP, 0.0.0.0, is not working in my case. Replacing it with 127.0.0.1 works fine. So I added a ReceiveIp settings.

I made sure to follow your coding style / naming convention.

![image](https://user-images.githubusercontent.com/7646137/112722463-05855080-8f0a-11eb-9914-5fcb53d59d5a.png)

Note: compilation is successful on UE 4.26.1
